### PR TITLE
Update SubmitViewController.swift

### DIFF
--- a/Classic/project33/Project33/SubmitViewController.swift
+++ b/Classic/project33/Project33/SubmitViewController.swift
@@ -40,8 +40,8 @@ class SubmitViewController: UIViewController {
 		status.font = UIFont.preferredFont(forTextStyle: .title1)
 		status.numberOfLines = 0
 		status.textAlignment = .center
-
-		spinner = UIActivityIndicatorView(style: .whiteLarge)
+		
+		spinner = UIActivityIndicatorView(style: .large)
 		spinner.translatesAutoresizingMaskIntoConstraints = false
 		spinner.hidesWhenStopped = true
 		spinner.startAnimating()


### PR DESCRIPTION
replaced spinner = UIActivityIndicatorView(style: .whiteLarge) 
with 
spinner = UIActivityIndicatorView(style: .large)
'whiteLarge' was deprecated in iOS 13.0: renamed to 'UIActivityIndicatorView.Style.large'